### PR TITLE
Add try-except around hashlib.md5 calls passing usedforsecurity=False

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -617,7 +617,7 @@ class UnsaltedMD5PasswordHasher(BasePasswordHasher):
         try:
             return hashlib.md5(force_bytes(password), usedforsecurity=False).hexdigest()
         except TypeError:
-            return hashlib.md5(force_bytes(password), usedforsecurity=False).hexdigest()
+            return hashlib.md5(force_bytes(password)).hexdigest()
 
     def verify(self, password, encoded):
         if len(encoded) == 37 and encoded.startswith('md5$$'):

--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -82,7 +82,18 @@ class HashedFilesMixin(object):
         """
         if content is None:
             return None
-        md5 = hashlib.md5(usedforsecurity=False)
+
+        # Current stable version of python does not have FIPS support for hashlib. Passing
+        # usedforsecurity=False only works in RHEL versions of python, and is needed to
+        # run this code on hardened RHEL machines. The try-except block will not be needed once
+        # the following issue is resolved:
+        #
+        # https://bugs.python.org/issue9216
+        try:
+            md5 = hashlib.md5(usedforsecurity=False)
+        except TypeError:
+            md5 = hashlib.md5()
+
         for chunk in content.chunks():
             md5.update(chunk)
         return md5.hexdigest()[:12]
@@ -479,7 +490,17 @@ class CachedFilesMixin(HashedFilesMixin):
             self.hashed_files = _MappingCache(default_cache)
 
     def hash_key(self, name):
-        key = hashlib.md5(force_bytes(self.clean_name(name)), usedforsecurity=False).hexdigest()
+        # Current stable version of python does not have FIPS support for hashlib. Passing
+        # usedforsecurity=False only works in RHEL versions of python, and is needed to
+        # run this code on hardened RHEL machines. The try-except block will not be needed once
+        # the following issue is resolved:
+        #
+        # https://bugs.python.org/issue9216
+        try:
+            key = hashlib.md5(force_bytes(self.clean_name(name)), usedforsecurity=False).hexdigest()
+        except TypeError:
+            key = hashlib.md5(force_bytes(self.clean_name(name))).hexdigest()
+
         return 'staticfiles:%s' % key
 
 

--- a/django/core/cache/utils.py
+++ b/django/core/cache/utils.py
@@ -20,8 +20,8 @@ def make_template_fragment_key(fragment_name, vary_on=None):
     #
     # https://bugs.python.org/issue9216
     try:
-	    args = hashlib.md5(force_bytes(key), usedforsecurity=False)
-	except TypeError:
-	    args = hashlib.md5(force_bytes(key))
+        args = hashlib.md5(force_bytes(key), usedforsecurity=False)
+    except TypeError:
+        args = hashlib.md5(force_bytes(key))
 
     return TEMPLATE_FRAGMENT_KEY_TEMPLATE % (fragment_name, args.hexdigest())

--- a/django/core/cache/utils.py
+++ b/django/core/cache/utils.py
@@ -12,5 +12,16 @@ def make_template_fragment_key(fragment_name, vary_on=None):
     if vary_on is None:
         vary_on = ()
     key = ':'.join(urlquote(var) for var in vary_on)
-    args = hashlib.md5(force_bytes(key), usedforsecurity=False)
+
+    # Current stable version of python does not have FIPS support for hashlib. Passing
+    # usedforsecurity=False only works in RHEL versions of python, and is needed to
+    # run this code on hardened RHEL machines. The try-except block will not be needed once
+    # the following issue is resolved:
+    #
+    # https://bugs.python.org/issue9216
+    try:
+	    args = hashlib.md5(force_bytes(key), usedforsecurity=False)
+	except TypeError:
+	    args = hashlib.md5(force_bytes(key))
+
     return TEMPLATE_FRAGMENT_KEY_TEMPLATE % (fragment_name, args.hexdigest())

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -144,7 +144,18 @@ class BaseDatabaseSchemaEditor(object):
         Generates a 32-bit digest of a set of arguments that can be used to
         shorten identifying names.
         """
-        h = hashlib.md5(usedforsecurity=False)
+
+        # Current stable version of python does not have FIPS support for hashlib. Passing
+        # usedforsecurity=False only works in RHEL versions of python, and is needed to
+        # run this code on hardened RHEL machines. The try-except block will not be needed once
+        # the following issue is resolved:
+        #
+        # https://bugs.python.org/issue9216
+        try:
+            h = hashlib.md5(usedforsecurity=False)
+        except TypeError:
+            h = hashlib.md5()
+
         for arg in args:
             h.update(force_bytes(arg))
         return h.hexdigest()[:8]

--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -206,7 +206,17 @@ def truncate_name(identifier, length=None, hash_len=4):
     if length is None or len(name) <= length:
         return identifier
 
-    digest = hashlib.md5(force_bytes(name), usedforsecurity=False).hexdigest()[:hash_len]
+    # Current stable version of python does not have FIPS support for hashlib. Passing
+    # usedforsecurity=False only works in RHEL versions of python, and is needed to
+    # run this code on hardened RHEL machines. The try-except block will not be needed once
+    # the following issue is resolved:
+    #
+    # https://bugs.python.org/issue9216
+    try:
+        digest = hashlib.md5(force_bytes(name), usedforsecurity=False).hexdigest()[:hash_len]
+    except TypeError:
+        digest = hashlib.md5(force_bytes(name)).hexdigest()[:hash_len]
+
     return '%s%s%s' % ('%s"."' % namespace if namespace else '', name[:length - hash_len], digest)
 
 

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -89,7 +89,18 @@ class Index(object):
         Generate a 32-bit digest of a set of arguments that can be used to
         shorten identifying names.
         """
-        h = hashlib.md5(usedforsecurity=False)
+
+        # Current stable version of python does not have FIPS support for hashlib. Passing
+        # usedforsecurity=False only works in RHEL versions of python, and is needed to
+        # run this code on hardened RHEL machines. The try-except block will not be needed once
+        # the following issue is resolved:
+        #
+        # https://bugs.python.org/issue9216
+        try:
+            h = hashlib.md5(usedforsecurity=False)
+        except TypeError:
+            h = hashlib.md5()
+
         for arg in args:
             h.update(force_bytes(arg))
         return h.hexdigest()[:6]

--- a/django/utils/cache.py
+++ b/django/utils/cache.py
@@ -106,7 +106,17 @@ def get_max_age(response):
 
 def set_response_etag(response):
     if not response.streaming:
-        response['ETag'] = quote_etag(hashlib.md5(response.content, usedforsecurity=False).hexdigest())
+        # Current stable version of python does not have FIPS support for hashlib. Passing
+        # usedforsecurity=False only works in RHEL versions of python, and is needed to
+        # run this code on hardened RHEL machines. The try-except block will not be needed once
+        # the following issue is resolved:
+        #
+        # https://bugs.python.org/issue9216
+        try:
+            response['ETag'] = quote_etag(hashlib.md5(response.content, usedforsecurity=False).hexdigest())
+        except TypeError:
+            response['ETag'] = quote_etag(hashlib.md5(response.content).hexdigest())
+
     return response
 
 
@@ -325,12 +335,28 @@ def _i18n_cache_key_suffix(request, cache_key):
 
 def _generate_cache_key(request, method, headerlist, key_prefix):
     """Returns a cache key from the headers given in the header list."""
-    ctx = hashlib.md5(usedforsecurity=False)
+
+    # Current stable version of python does not have FIPS support for hashlib. Passing
+    # usedforsecurity=False only works in RHEL versions of python, and is needed to
+    # run this code on hardened RHEL machines. The try-except block will not be needed once
+    # the following issue is resolved:
+    #
+    # https://bugs.python.org/issue9216
+    try:
+        ctx = hashlib.md5(usedforsecurity=False)
+    except TypeError:
+        ctx = hashlib.md5()
+
     for header in headerlist:
         value = request.META.get(header)
         if value is not None:
             ctx.update(force_bytes(value))
-    url = hashlib.md5(force_bytes(iri_to_uri(request.build_absolute_uri())), usedforsecurity=False)
+
+    try:
+        url = hashlib.md5(force_bytes(iri_to_uri(request.build_absolute_uri())), usedforsecurity=False)
+    except TypeError:
+        url = hashlib.md5(force_bytes(iri_to_uri(request.build_absolute_uri())))
+
     cache_key = 'views.decorators.cache.cache_page.%s.%s.%s.%s' % (
         key_prefix, method, url.hexdigest(), ctx.hexdigest())
     return _i18n_cache_key_suffix(request, cache_key)
@@ -338,7 +364,18 @@ def _generate_cache_key(request, method, headerlist, key_prefix):
 
 def _generate_cache_header_key(key_prefix, request):
     """Returns a cache key for the header cache."""
-    url = hashlib.md5(force_bytes(iri_to_uri(request.build_absolute_uri())), usedforsecurity=False)
+
+    # Current stable version of python does not have FIPS support for hashlib. Passing
+    # usedforsecurity=False only works in RHEL versions of python, and is needed to
+    # run this code on hardened RHEL machines. The try-except block will not be needed once
+    # the following issue is resolved:
+    #
+    # https://bugs.python.org/issue9216
+    try:
+        url = hashlib.md5(force_bytes(iri_to_uri(request.build_absolute_uri())), usedforsecurity=False)
+    except TypeError:
+        url = hashlib.md5(force_bytes(iri_to_uri(request.build_absolute_uri())))
+
     cache_key = 'views.decorators.cache.cache_header.%s.%s' % (
         key_prefix, url.hexdigest())
     return _i18n_cache_key_suffix(request, cache_key)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ EXCLUDE_FROM_PACKAGES = ['django.conf.project_template',
 
 # Dynamically calculate the version based on django.VERSION.
 version = __import__('django').get_version()
-nimbis_version = '2'
+nimbis_version = '3'
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ EXCLUDE_FROM_PACKAGES = ['django.conf.project_template',
 
 # Dynamically calculate the version based on django.VERSION.
 version = __import__('django').get_version()
-nimbis_version = '1'
+nimbis_version = '2'
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ EXCLUDE_FROM_PACKAGES = ['django.conf.project_template',
 
 # Dynamically calculate the version based on django.VERSION.
 version = __import__('django').get_version()
-nimbis_version = '3'
+nimbis_version = '4'
 
 
 setup(


### PR DESCRIPTION
An exception is currently thrown if passing the usedforsecurity=False
flag when calling hashlib.md5 using a version of python that currently
does not support FIPS.

At the time of this commit, the RHEL version of python supported
this, however, other versions did not. This issue is captured here:
https://bugs.python.org/issue9216

These changes can be dropped once that issue is resolved.